### PR TITLE
Fix item not registering as scrap

### DIFF
--- a/src/Plugin.cs
+++ b/src/Plugin.cs
@@ -88,7 +88,7 @@ namespace LCOuijaBoard
                 Debug.Log($"Ouija Board store enabled at {storeCost} credits");
                 Items.RegisterShopItem(storeItem, storeCost);
             }
-            if (storeEnabled)
+            if (scrapEnabled)
             {
                 Debug.Log($"Ouija Board scrap spawn enabled at {scrapRarity} rarity weight");
                 Items.RegisterScrap(scrapItem, scrapRarity, Levels.LevelTypes.All);


### PR DESCRIPTION
This PR fixes a bug when Ouija Board isn't registering as scrap when `storeEnabled = false`